### PR TITLE
Added new status code errors to MetadataServiceKeyAlreadyExistsError …

### DIFF
--- a/docs/api/pyxcli/errors.rst
+++ b/docs/api/pyxcli/errors.rst
@@ -71,6 +71,8 @@
    .. autoclass:: pyxcli.errors.MetadataServiceDBAlreadyExistsError
    .. autoclass:: pyxcli.errors.MetadataServiceKeyDoesNotExistError
    .. autoclass:: pyxcli.errors.MetadataServiceKeyAlreadyExistsError
+   .. autoclass:: pyxcli.errors.KeyExistsError
+   .. autoclass:: pyxcli.errors.KeyDoesNotExistError
    .. autoclass:: pyxcli.errors.MetadataServiceMaxEntriesReachedError
    .. autoclass:: pyxcli.errors.MetadataServiceInvalidTokenError
    .. autoclass:: pyxcli.errors.LDAPAuthenticationIsNotActive

--- a/pyxcli/__init__.py
+++ b/pyxcli/__init__.py
@@ -22,7 +22,7 @@ IBM XCLI Client Module
 XCLI_DEFAULT_LOGGER = "xcli"
 XCLI_DEFAULT_PORT = 7778
 
-version_tuple = (1, 1, 5)
+version_tuple = (1, 1, 7)
 
 
 def get_version_string():

--- a/pyxcli/errors.py
+++ b/pyxcli/errors.py
@@ -440,8 +440,18 @@ class MetadataServiceKeyDoesNotExistError(CommandFailedRuntimeError):
     pass
 
 
+@CommandExecutionError.register("KEY_DOES_NOT_EXIST")
+class KeyDoesNotExistError(CommandFailedRuntimeError):
+    pass
+
+
 @CommandExecutionError.register("STATUS_METADATA_SERVICE_KEY_ALREADY_EXISTS")
 class MetadataServiceKeyAlreadyExistsError(CommandFailedRuntimeError):
+    pass
+
+
+@CommandExecutionError.register("KEY_EXISTS")
+class KeyExistsError(CommandFailedRuntimeError):
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     name='pyxcli',
     version=pyxcli.version,
     description="IBM Python XCLI Client",
+    long_description="IBM Python XCLI Client for Spectrum Accelerate Storage Family.",
     author="Tzur Eliyahu, Alon Marx",
     author_email="tzure@il.ibm.com",
     maintainer="Tzur Eliyahu, Alon Marx",


### PR DESCRIPTION
…… (#8)

* Added new status code errors to MetadataServiceKeyAlreadyExistsError and MetadataServiceKeyDoesNotExistError

* Added new status code errors to MetadataServiceKeyAlreadyExistsError and MetadataServiceKeyDoesNotExistError

* Separate errors for 'KEY_EXISTS' 'KEY_DOES_NOT_EXIST'

* Added KeyExistsError and KeyDoesNotExistError to errors.rst documentation file

* Changed version from 1.1.6 to 1.1.7